### PR TITLE
fix: escape Instana API URL values and guard handler panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix: URL-escape values interpolated into Instana API requests — the maintenance-window id (derived from the experiment key) is path-escaped and the application/event query parameters are query-escaped, preventing path traversal and query-parameter injection
+- fix: guard the event check and maintenance-window actions against missing target attributes and non-numeric duration config instead of panicking
+
 ## v1.1.18
 
 - chore(deps): bump github.com/steadybit/extension-kit

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steadybit/extension-instana/types"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -41,9 +42,9 @@ func ParseConfiguration() {
 	Config.BaseUrl = strings.TrimSuffix(Config.BaseUrl, "/")
 }
 func (s *Specification) GetSnapshotIds(_ context.Context, applicationPerspectiveId string) ([]string, error) {
-	url := fmt.Sprintf("%s/api/infrastructure-monitoring/snapshots?query=entity.application.id:%s&size=20000", s.BaseUrl, applicationPerspectiveId)
+	requestUrl := fmt.Sprintf("%s/api/infrastructure-monitoring/snapshots?query=entity.application.id:%s&size=20000", s.BaseUrl, url.QueryEscape(applicationPerspectiveId))
 
-	responseBody, response, err := s.do(url, "GET", nil)
+	responseBody, response, err := s.do(requestUrl, "GET", nil)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get snapshot-ids from Instana. Full response %+v", string(responseBody))
 		return nil, err
@@ -77,12 +78,12 @@ func (s *Specification) GetSnapshotIds(_ context.Context, applicationPerspective
 }
 
 func (s *Specification) GetEvents(_ context.Context, from time.Time, to time.Time, eventTypeFilters []string) ([]types.Event, error) {
-	url := fmt.Sprintf("%s/api/events?from=%d&to=%d", s.BaseUrl, from.UnixMilli(), to.UnixMilli())
+	requestUrl := fmt.Sprintf("%s/api/events?from=%d&to=%d", s.BaseUrl, from.UnixMilli(), to.UnixMilli())
 	for _, eventTypeFilter := range eventTypeFilters {
-		url = fmt.Sprintf("%s&eventTypeFilters=%s", url, eventTypeFilter)
+		requestUrl = fmt.Sprintf("%s&eventTypeFilters=%s", requestUrl, url.QueryEscape(eventTypeFilter))
 	}
 
-	responseBody, response, err := s.do(url, "GET", nil)
+	responseBody, response, err := s.do(requestUrl, "GET", nil)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get events from Instana. Full response %+v", string(responseBody))
 		return nil, err
@@ -140,7 +141,7 @@ func (s *Specification) CreateMaintenanceWindow(_ context.Context, maintenanceWi
 		return nil, nil, err
 	}
 
-	responseBody, response, err := s.do(fmt.Sprintf("%s/api/settings/v2/maintenance/%s", s.BaseUrl, maintenanceWindow.Id), "PUT", b)
+	responseBody, response, err := s.do(fmt.Sprintf("%s/api/settings/v2/maintenance/%s", s.BaseUrl, url.PathEscape(maintenanceWindow.Id)), "PUT", b)
 	if err != nil {
 		return nil, response, err
 	}
@@ -163,7 +164,7 @@ func (s *Specification) CreateMaintenanceWindow(_ context.Context, maintenanceWi
 }
 
 func (s *Specification) DeleteMaintenanceWindow(_ context.Context, maintenanceWindowId string) (*http.Response, error) {
-	_, response, err := s.do(fmt.Sprintf("%s/api/settings/v2/maintenance/%s", s.BaseUrl, maintenanceWindowId), "DELETE", nil)
+	_, response, err := s.do(fmt.Sprintf("%s/api/settings/v2/maintenance/%s", s.BaseUrl, url.PathEscape(maintenanceWindowId)), "DELETE", nil)
 	return response, err
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025 steadybit GmbH. All rights reserved.
+
+package config
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/steadybit/extension-instana/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSnapshotIds_EscapesApplicationPerspectiveId(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer srv.Close()
+
+	spec := Specification{BaseUrl: srv.URL, ApiToken: "X"}
+	// An id that tries to inject an extra query parameter (override the size limit).
+	_, err := spec.GetSnapshotIds(context.Background(), "app-1&size=1")
+	require.NoError(t, err)
+
+	// Escaped properly, the injected text stays inside the query value...
+	assert.Equal(t, "entity.application.id:app-1&size=1", gotQuery.Get("query"))
+	// ...and does not override the size parameter.
+	assert.Equal(t, "20000", gotQuery.Get("size"))
+}
+
+func TestGetEvents_EscapesEventTypeFilter(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	spec := Specification{BaseUrl: srv.URL, ApiToken: "X"}
+	_, err := spec.GetEvents(context.Background(), time.Time{}, time.Time{}, []string{"incident&to=0"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"incident&to=0"}, gotQuery["eventTypeFilters"])
+}
+
+func TestCreateMaintenanceWindow_EscapesIdInPath(t *testing.T) {
+	var gotEscapedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"x"}`))
+	}))
+	defer srv.Close()
+
+	spec := Specification{BaseUrl: srv.URL, ApiToken: "X"}
+	// An id (derived from the experiment key) trying to traverse the path.
+	_, _, err := spec.CreateMaintenanceWindow(context.Background(), types.CreateMaintenanceWindowRequest{Id: "exp/../../evil"})
+	require.NoError(t, err)
+
+	// The '/' must be percent-encoded so the id stays a single path segment.
+	assert.Equal(t, "/api/settings/v2/maintenance/exp%2F..%2F..%2Fevil", gotEscapedPath)
+}

--- a/extevents/event_check.go
+++ b/extevents/event_check.go
@@ -195,7 +195,7 @@ func (m *EventCheckAction) Describe() action_kit_api.ActionDescription {
 }
 
 func (m *EventCheckAction) Prepare(ctx context.Context, state *EventCheckState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
-	duration := request.Config["duration"].(float64)
+	duration := extutil.ToInt64(request.Config["duration"])
 	state.Start = time.Now()
 	state.End = time.Now().Add(time.Millisecond * time.Duration(duration))
 
@@ -223,7 +223,11 @@ func (m *EventCheckAction) Prepare(ctx context.Context, state *EventCheckState, 
 		state.ConditionCheckMode = fmt.Sprintf("%v", request.Config["conditionCheckMode"])
 	}
 
-	applicationPerspectiveId := request.Target.Attributes["instana.application.id"][0]
+	applicationPerspectiveIds := request.Target.Attributes["instana.application.id"]
+	if len(applicationPerspectiveIds) == 0 {
+		return nil, extension_kit.ToError("Target is missing the 'instana.application.id' attribute.", nil)
+	}
+	applicationPerspectiveId := applicationPerspectiveIds[0]
 	snapshotIds, err := config.Config.GetSnapshotIds(ctx, applicationPerspectiveId)
 	if err != nil {
 		return nil, extension_kit.ToError("Failed to get snapshot-ids from Instana.", err)

--- a/extmaintenance/maintenance.go
+++ b/extmaintenance/maintenance.go
@@ -78,10 +78,14 @@ func (m *CreateMaintenanceWindowAction) Describe() action_kit_api.ActionDescript
 }
 
 func (m *CreateMaintenanceWindowAction) Prepare(_ context.Context, state *CreateMaintenanceWindowState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
-	state.ApplicationPerspectiveId = request.Target.Attributes["instana.application.id"][0]
+	applicationPerspectiveIds := request.Target.Attributes["instana.application.id"]
+	if len(applicationPerspectiveIds) == 0 {
+		return nil, extension_kit.ToError("Target is missing the 'instana.application.id' attribute.", nil)
+	}
+	state.ApplicationPerspectiveId = applicationPerspectiveIds[0]
 	state.ExperimentKey = request.ExecutionContext.ExperimentKey
 	state.ExecutionId = request.ExecutionContext.ExecutionId
-	state.DurationInMillis = int64(request.Config["duration"].(float64))
+	state.DurationInMillis = extutil.ToInt64(request.Config["duration"])
 	return nil, nil
 }
 


### PR DESCRIPTION
Addresses the instana audit MAJOR findings.

## 1. Path traversal / request manipulation (MAJOR)

The maintenance-window **id is derived from the user-controlled experiment key** and was interpolated raw into the API URL **path**:

```go
s.do(fmt.Sprintf("%s/api/settings/v2/maintenance/%s", s.BaseUrl, maintenanceWindow.Id), "PUT", b)
```

An experiment key containing `/`, `..`, `?`, `#` could alter the request path against the authenticated Instana API. **Fix:** `url.PathEscape` the id in both `CreateMaintenanceWindow` and `DeleteMaintenanceWindow`.

## 2. Query-parameter injection (MAJOR)

`applicationPerspectiveId` (snapshots query) and `eventTypeFilters` (events query) were interpolated raw into query strings. **Fix:** `url.QueryEscape` both. (The shadowing local `url` variable was renamed to `requestUrl` so `net/url` is callable.)

## 3. Handler panics (MAJOR)

- `request.Target.Attributes["instana.application.id"][0]` was indexed without a length check (event check + maintenance) → index panic on a target missing the attribute. Now length-guarded with a clear error.
- `request.Config["duration"].(float64)` unchecked type assertion → panic on a missing/non-float value. Now `extutil.ToInt64` (the idiomatic action-kit helper).

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.
- New `config/config_test.go` (httptest-based): the application id stays inside the query value and does not override `size`; an event-type filter with `&to=0` does not inject a parameter; a maintenance id of `exp/../../evil` is path-escaped to `exp%2F..%2F..%2Fevil` (single path segment, no traversal).
- `go test ./config/` passes.

## /simplify
4-agent pass: reuse/simplification/efficiency clean. The altitude agent confirmed **no user-influenced value reaching a URL is left unescaped** after the fix, and that a `url.Values`/`url.URL` rewrite would be disproportionate (only the leaf values are user data; the URL structure is static). It also confirmed `maintenance.go`'s `Query` field goes into a JSON body (json-escaped, not a URL) and `ExecutionContext` is a value field (no nil-deref) — both correctly out of scope. Applied one trivial naming-consistency tidy.